### PR TITLE
Model entity references with IEnumerable navigations

### DIFF
--- a/ApiSunSale.Application/DTO/AnexorespostaDTO.cs
+++ b/ApiSunSale.Application/DTO/AnexorespostaDTO.cs
@@ -5,5 +5,6 @@ namespace ApiSunSale.Application.DTO
         public long Id { get; set; }
         public long Idquestao { get; set; }
         public byte[] Anexo { get; set; }
+        public QuestoesDTO Questao { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/AnexosquestoesDTO.cs
+++ b/ApiSunSale.Application/DTO/AnexosquestoesDTO.cs
@@ -5,5 +5,6 @@ namespace ApiSunSale.Application.DTO
         public long Id { get; set; }
         public long Idquestao { get; set; }
         public string Link { get; set; }
+        public QuestoesDTO Questao { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/AvaliacaoDTO.cs
+++ b/ApiSunSale.Application/DTO/AvaliacaoDTO.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Application.DTO
 {
     public class AvaliacaoDTO : BaseDTO
@@ -7,5 +9,8 @@ namespace ApiSunSale.Application.DTO
         public string Orientação { get; set; }
         public string Ispublic { get; set; }
         public string Key { get; set; }
+
+        public IEnumerable<QuestoesavaliacaoDTO> Questoesavaliacao { get; set; }
+        public IEnumerable<RespostasavaliacoesDTO> Respostasavaliacoes { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/ComentariosquestoesDTO.cs
+++ b/ApiSunSale.Application/DTO/ComentariosquestoesDTO.cs
@@ -6,5 +6,7 @@ namespace ApiSunSale.Application.DTO
         public string Comentario { get; set; }
         public long Idusuario { get; set; }
         public long Idquestao { get; set; }
+        public UsuariosDTO Usuario { get; set; }
+        public QuestoesDTO Questao { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/ProvaDTO.cs
+++ b/ApiSunSale.Application/DTO/ProvaDTO.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace ApiSunSale.Application.DTO
 {
     public class ProvaDTO : BaseDTO
@@ -15,5 +18,6 @@ namespace ApiSunSale.Application.DTO
         public string Banca { get; set; }
         public long Updatedby { get; set; }
         public long Createdby { get; set; }
+        public IEnumerable<QuestoesDTO> Questoes { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/QuestoesDTO.cs
+++ b/ApiSunSale.Application/DTO/QuestoesDTO.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Application.DTO
 {
     public class QuestoesDTO : BaseDTO
@@ -11,5 +13,13 @@ namespace ApiSunSale.Application.DTO
         public long Updatedby { get; set; }
         public long Createdby { get; set; }
         public string Assunto { get; set; }
+        public ProvaDTO Prova { get; set; }
+        public IEnumerable<AnexorespostaDTO> Anexosresposta { get; set; }
+        public IEnumerable<AnexosquestoesDTO> Anexosquestoes { get; set; }
+        public IEnumerable<ComentariosquestoesDTO> Comentariosquestoes { get; set; }
+        public IEnumerable<RespostasquestoesDTO> Respostasquestoes { get; set; }
+        public IEnumerable<RespostasusuariosDTO> Respostasusuarios { get; set; }
+        public IEnumerable<RespostasavaliacoesDTO> Respostasavaliacoes { get; set; }
+        public IEnumerable<QuestoesavaliacaoDTO> Questoesavaliacao { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/QuestoesavaliacaoDTO.cs
+++ b/ApiSunSale.Application/DTO/QuestoesavaliacaoDTO.cs
@@ -6,5 +6,7 @@ namespace ApiSunSale.Application.DTO
         public long Idavaliacao { get; set; }
         public long Idquestao { get; set; }
         public decimal Notaquestao { get; set; }
+        public AvaliacaoDTO Avaliacao { get; set; }
+        public QuestoesDTO Questao { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/RespostasavaliacoesDTO.cs
+++ b/ApiSunSale.Application/DTO/RespostasavaliacoesDTO.cs
@@ -8,5 +8,8 @@ namespace ApiSunSale.Application.DTO
         public long Idavaliacao { get; set; }
         public long Idquestao { get; set; }
         public long Idresposta { get; set; }
+        public AvaliacaoDTO Avaliacao { get; set; }
+        public QuestoesDTO Questao { get; set; }
+        public RespostasquestoesDTO Resposta { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/RespostasquestoesDTO.cs
+++ b/ApiSunSale.Application/DTO/RespostasquestoesDTO.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Application.DTO
 {
     public class RespostasquestoesDTO : BaseDTO
@@ -7,5 +9,8 @@ namespace ApiSunSale.Application.DTO
         public string Textoresposta { get; set; }
         public string Certa { get; set; }
         public string Observacaoresposta { get; set; }
+        public QuestoesDTO Questao { get; set; }
+        public IEnumerable<RespostasavaliacoesDTO> Respostasavaliacoes { get; set; }
+        public IEnumerable<RespostasusuariosDTO> Respostasusuarios { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/RespostasusuariosDTO.cs
+++ b/ApiSunSale.Application/DTO/RespostasusuariosDTO.cs
@@ -6,5 +6,8 @@ namespace ApiSunSale.Application.DTO
         public long Idusuario { get; set; }
         public long Idresposta { get; set; }
         public long Idquestao { get; set; }
+        public UsuariosDTO Usuario { get; set; }
+        public RespostasquestoesDTO Resposta { get; set; }
+        public QuestoesDTO Questao { get; set; }
     }
 }

--- a/ApiSunSale.Application/DTO/UsuariosDTO.cs
+++ b/ApiSunSale.Application/DTO/UsuariosDTO.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace ApiSunSale.Application.DTO
 {
     public class UsuariosDTO : BaseDTO
@@ -10,5 +13,8 @@ namespace ApiSunSale.Application.DTO
         public DateTime Datanascimento { get; set; }
         public string Admin { get; set; }
         public string Instituicao { get; set; }
+
+        public IEnumerable<ComentariosquestoesDTO> Comentariosquestoes { get; set; }
+        public IEnumerable<RespostasusuariosDTO> Respostasusuarios { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Anexoresposta.cs
+++ b/ApiSunSale.Domain/Entities/Anexoresposta.cs
@@ -5,5 +5,7 @@ namespace ApiSunSale.Domain.Entities
         public long Id { get; set; }
         public long Idquestao { get; set; }
         public byte[] Anexo { get; set; }
+
+        public Questoes Questao { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Anexosquestoes.cs
+++ b/ApiSunSale.Domain/Entities/Anexosquestoes.cs
@@ -5,5 +5,7 @@ namespace ApiSunSale.Domain.Entities
         public long Id { get; set; }
         public long Idquestao { get; set; }
         public string Link { get; set; }
+
+        public Questoes Questao { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Avaliacao.cs
+++ b/ApiSunSale.Domain/Entities/Avaliacao.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Domain.Entities
 {
     public class Avaliacao : BaseEntity
@@ -7,5 +9,8 @@ namespace ApiSunSale.Domain.Entities
         public string Orientação { get; set; }
         public string Ispublic { get; set; }
         public string Key { get; set; }
+
+        public IEnumerable<Questoesavaliacao> Questoesavaliacao { get; set; }
+        public IEnumerable<Respostasavaliacoes> Respostasavaliacoes { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Comentariosquestoes.cs
+++ b/ApiSunSale.Domain/Entities/Comentariosquestoes.cs
@@ -6,5 +6,8 @@ namespace ApiSunSale.Domain.Entities
         public string Comentario { get; set; }
         public long Idusuario { get; set; }
         public long Idquestao { get; set; }
+
+        public Usuarios Usuario { get; set; }
+        public Questoes Questao { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Prova.cs
+++ b/ApiSunSale.Domain/Entities/Prova.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ApiSunSale.Domain.Entities
@@ -18,5 +20,7 @@ namespace ApiSunSale.Domain.Entities
         public string Banca { get; set; }
         public long Updatedby { get; set; }
         public long Createdby { get; set; }
+
+        public IEnumerable<Questoes> Questoes { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Questoes.cs
+++ b/ApiSunSale.Domain/Entities/Questoes.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Domain.Entities
 {
     public class Questoes : BaseEntity
@@ -11,5 +13,14 @@ namespace ApiSunSale.Domain.Entities
         public long Updatedby { get; set; }
         public long Createdby { get; set; }
         public string Assunto { get; set; }
+
+        public Prova Prova { get; set; }
+        public IEnumerable<Anexoresposta> Anexosresposta { get; set; }
+        public IEnumerable<Anexosquestoes> Anexosquestoes { get; set; }
+        public IEnumerable<Comentariosquestoes> Comentariosquestoes { get; set; }
+        public IEnumerable<Respostasquestoes> Respostasquestoes { get; set; }
+        public IEnumerable<Respostasusuarios> Respostasusuarios { get; set; }
+        public IEnumerable<Respostasavaliacoes> Respostasavaliacoes { get; set; }
+        public IEnumerable<Questoesavaliacao> Questoesavaliacao { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Questoesavaliacao.cs
+++ b/ApiSunSale.Domain/Entities/Questoesavaliacao.cs
@@ -6,5 +6,8 @@ namespace ApiSunSale.Domain.Entities
         public long Idavaliacao { get; set; }
         public long Idquestao { get; set; }
         public decimal Notaquestao { get; set; }
+
+        public Avaliacao Avaliacao { get; set; }
+        public Questoes Questao { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Respostasavaliacoes.cs
+++ b/ApiSunSale.Domain/Entities/Respostasavaliacoes.cs
@@ -8,5 +8,9 @@ namespace ApiSunSale.Domain.Entities
         public long Idavaliacao { get; set; }
         public long Idquestao { get; set; }
         public long Idresposta { get; set; }
+
+        public Avaliacao Avaliacao { get; set; }
+        public Questoes Questao { get; set; }
+        public Respostasquestoes Resposta { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Respostasquestoes.cs
+++ b/ApiSunSale.Domain/Entities/Respostasquestoes.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Domain.Entities
 {
     public class Respostasquestoes : BaseEntity
@@ -7,5 +9,9 @@ namespace ApiSunSale.Domain.Entities
         public string Textoresposta { get; set; }
         public string Certa { get; set; }
         public string Observacaoresposta { get; set; }
+
+        public Questoes Questao { get; set; }
+        public IEnumerable<Respostasavaliacoes> Respostasavaliacoes { get; set; }
+        public IEnumerable<Respostasusuarios> Respostasusuarios { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Respostasusuarios.cs
+++ b/ApiSunSale.Domain/Entities/Respostasusuarios.cs
@@ -6,5 +6,9 @@ namespace ApiSunSale.Domain.Entities
         public long Idusuario { get; set; }
         public long Idresposta { get; set; }
         public long Idquestao { get; set; }
+
+        public Usuarios Usuario { get; set; }
+        public Respostasquestoes Resposta { get; set; }
+        public Questoes Questao { get; set; }
     }
 }

--- a/ApiSunSale.Domain/Entities/Usuarios.cs
+++ b/ApiSunSale.Domain/Entities/Usuarios.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace ApiSunSale.Domain.Entities
 {
     public class Usuarios : BaseEntity
@@ -10,5 +13,8 @@ namespace ApiSunSale.Domain.Entities
         public DateTime Datanascimento { get; set; }
         public string Admin { get; set; }
         public string Instituicao { get; set; }
+
+        public IEnumerable<Comentariosquestoes> Comentariosquestoes { get; set; }
+        public IEnumerable<Respostasusuarios> Respostasusuarios { get; set; }
     }
 }

--- a/ApiSunSale.Infrastructure.Data/Context/ApiSunSaleContext.cs
+++ b/ApiSunSale.Infrastructure.Data/Context/ApiSunSaleContext.cs
@@ -103,6 +103,96 @@ namespace ApiSunSale.Infrastructure.Data.Context
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<Prova>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasMany(e => e.Questoes)
+                      .WithOne(q => q.Prova)
+                      .HasForeignKey(q => q.Idprova);
+            });
+
+            modelBuilder.Entity<Questoes>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Prova)
+                      .WithMany(p => p.Questoes)
+                      .HasForeignKey(e => e.Idprova);
+            });
+
+            modelBuilder.Entity<Anexoresposta>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Anexosresposta)
+                      .HasForeignKey(e => e.Idquestao);
+            });
+
+            modelBuilder.Entity<Anexosquestoes>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Anexosquestoes)
+                      .HasForeignKey(e => e.Idquestao);
+            });
+
+            modelBuilder.Entity<Comentariosquestoes>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Usuario)
+                      .WithMany(u => u.Comentariosquestoes)
+                      .HasForeignKey(e => e.Idusuario);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Comentariosquestoes)
+                      .HasForeignKey(e => e.Idquestao);
+            });
+
+            modelBuilder.Entity<Respostasquestoes>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Respostasquestoes)
+                      .HasForeignKey(e => e.Idquestao);
+            });
+
+            modelBuilder.Entity<Respostasusuarios>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Usuario)
+                      .WithMany(u => u.Respostasusuarios)
+                      .HasForeignKey(e => e.Idusuario);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Respostasusuarios)
+                      .HasForeignKey(e => e.Idquestao);
+                entity.HasOne(e => e.Resposta)
+                      .WithMany(r => r.Respostasusuarios)
+                      .HasForeignKey(e => e.Idresposta);
+            });
+
+            modelBuilder.Entity<Respostasavaliacoes>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Avaliacao)
+                      .WithMany(a => a.Respostasavaliacoes)
+                      .HasForeignKey(e => e.Idavaliacao);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Respostasavaliacoes)
+                      .HasForeignKey(e => e.Idquestao);
+                entity.HasOne(e => e.Resposta)
+                      .WithMany(r => r.Respostasavaliacoes)
+                      .HasForeignKey(e => e.Idresposta);
+            });
+
+            modelBuilder.Entity<Questoesavaliacao>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Avaliacao)
+                      .WithMany(a => a.Questoesavaliacao)
+                      .HasForeignKey(e => e.Idavaliacao);
+                entity.HasOne(e => e.Questao)
+                      .WithMany(q => q.Questoesavaliacao)
+                      .HasForeignKey(e => e.Idquestao);
+            });
         }
 
         public void CreateDefaultData(object model)

--- a/ApiSunSale.Presentation.Model/ViewModels/AnexorespostaViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/AnexorespostaViewModel.cs
@@ -5,5 +5,6 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public long Id { get; set; }
         public long Idquestao { get; set; }
         public byte[] Anexo { get; set; }
+        public QuestoesViewModel Questao { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/AnexosquestoesViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/AnexosquestoesViewModel.cs
@@ -5,5 +5,6 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public long Id { get; set; }
         public long Idquestao { get; set; }
         public string Link { get; set; }
+        public QuestoesViewModel Questao { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/AvaliacaoViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/AvaliacaoViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Presentation.Model.ViewModels
 {
     public class AvaliacaoViewModel : BaseViewModel
@@ -7,5 +9,8 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public string Orientação { get; set; }
         public string Ispublic { get; set; }
         public string Key { get; set; }
+
+        public IEnumerable<QuestoesavaliacaoViewModel> Questoesavaliacao { get; set; }
+        public IEnumerable<RespostasavaliacoesViewModel> Respostasavaliacoes { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/ComentariosquestoesViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/ComentariosquestoesViewModel.cs
@@ -6,5 +6,7 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public string Comentario { get; set; }
         public long Idusuario { get; set; }
         public long Idquestao { get; set; }
+        public UsuariosViewModel Usuario { get; set; }
+        public QuestoesViewModel Questao { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/ProvaViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/ProvaViewModel.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace ApiSunSale.Presentation.Model.ViewModels
 {
     public class ProvaViewModel : BaseViewModel
@@ -15,5 +18,6 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public string Banca { get; set; }
         public long Updatedby { get; set; }
         public long Createdby { get; set; }
+        public IEnumerable<QuestoesViewModel> Questoes { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/QuestoesViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/QuestoesViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Presentation.Model.ViewModels
 {
     public class QuestoesViewModel : BaseViewModel
@@ -11,5 +13,13 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public long Updatedby { get; set; }
         public long Createdby { get; set; }
         public string Assunto { get; set; }
+        public ProvaViewModel Prova { get; set; }
+        public IEnumerable<AnexorespostaViewModel> Anexosresposta { get; set; }
+        public IEnumerable<AnexosquestoesViewModel> Anexosquestoes { get; set; }
+        public IEnumerable<ComentariosquestoesViewModel> Comentariosquestoes { get; set; }
+        public IEnumerable<RespostasquestoesViewModel> Respostasquestoes { get; set; }
+        public IEnumerable<RespostasusuariosViewModel> Respostasusuarios { get; set; }
+        public IEnumerable<RespostasavaliacoesViewModel> Respostasavaliacoes { get; set; }
+        public IEnumerable<QuestoesavaliacaoViewModel> Questoesavaliacao { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/QuestoesavaliacaoViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/QuestoesavaliacaoViewModel.cs
@@ -6,5 +6,7 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public long Idavaliacao { get; set; }
         public long Idquestao { get; set; }
         public decimal Notaquestao { get; set; }
+        public AvaliacaoViewModel Avaliacao { get; set; }
+        public QuestoesViewModel Questao { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/RespostasavaliacoesViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/RespostasavaliacoesViewModel.cs
@@ -8,5 +8,8 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public long Idavaliacao { get; set; }
         public long Idquestao { get; set; }
         public long Idresposta { get; set; }
+        public AvaliacaoViewModel Avaliacao { get; set; }
+        public QuestoesViewModel Questao { get; set; }
+        public RespostasquestoesViewModel Resposta { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/RespostasquestoesViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/RespostasquestoesViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ApiSunSale.Presentation.Model.ViewModels
 {
     public class RespostasquestoesViewModel : BaseViewModel
@@ -7,5 +9,8 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public string Textoresposta { get; set; }
         public string Certa { get; set; }
         public string Observacaoresposta { get; set; }
+        public QuestoesViewModel Questao { get; set; }
+        public IEnumerable<RespostasavaliacoesViewModel> Respostasavaliacoes { get; set; }
+        public IEnumerable<RespostasusuariosViewModel> Respostasusuarios { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/RespostasusuariosViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/RespostasusuariosViewModel.cs
@@ -6,5 +6,8 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public long Idusuario { get; set; }
         public long Idresposta { get; set; }
         public long Idquestao { get; set; }
+        public UsuariosViewModel Usuario { get; set; }
+        public RespostasquestoesViewModel Resposta { get; set; }
+        public QuestoesViewModel Questao { get; set; }
     }
 }

--- a/ApiSunSale.Presentation.Model/ViewModels/UsuariosViewModel.cs
+++ b/ApiSunSale.Presentation.Model/ViewModels/UsuariosViewModel.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace ApiSunSale.Presentation.Model.ViewModels
 {
     public class UsuariosViewModel : BaseViewModel
@@ -10,5 +13,8 @@ namespace ApiSunSale.Presentation.Model.ViewModels
         public DateTime Datanascimento { get; set; }
         public string Admin { get; set; }
         public string Instituicao { get; set; }
+
+        public IEnumerable<ComentariosquestoesViewModel> Comentariosquestoes { get; set; }
+        public IEnumerable<RespostasusuariosViewModel> Respostasusuarios { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- expose relationships among questions, answers, comments and evaluations using `IEnumerable` navigation properties
- map the new associations in `ApiSunSaleContext` and mirror them in DTOs and view models

## Testing
- ⚠️ `dotnet build ApiSunSale.sln` *(command failed: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a118c4d7f0832ca2cf2f99cd9d1a0f